### PR TITLE
JDO-778: Adding overloaded methods to JDOQLTypedQuery to create a cor…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </scm>
 
     <properties>
-        <dn.javax.jdo.version>3.2.0-m12</dn.javax.jdo.version>
+        <dn.javax.jdo.version>3.2.0-m13-SNAPSHOT</dn.javax.jdo.version>
         <dn.core.version>5.2.0-release</dn.core.version>
     </properties>
 

--- a/src/main/java/org/datanucleus/api/jdo/query/JDOQLTypedQueryImpl.java
+++ b/src/main/java/org/datanucleus/api/jdo/query/JDOQLTypedQueryImpl.java
@@ -864,24 +864,48 @@ public class JDOQLTypedQueryImpl<T> extends AbstractJDOQLTypedQuery<T> implement
     }
 
     @Override
-    public <E> JDOQLTypedSubquery<E> subquery(CollectionExpression<Collection<E>, E> candidateCollection, String candidateAlias)
+    public <E> JDOQLTypedSubquery<E> subquery(CollectionExpression<Collection<E>, E> candidateCollection, Class<E> candidateClass, String candidateAlias)
     {
-        // TODO Implement me
-        throw new JDOException("Method not implemented. Please contribute an implementation via a GitHub pull request");
+        assertIsOpen();
+        discardCompiled();
+        JDOQLTypedSubqueryImpl<E> subquery = new JDOQLTypedSubqueryImpl<E>(pm, this.candidateCls, candidateAlias,
+                (CollectionExpressionImpl)candidateCollection, this);
+        if (subqueries == null)
+        {
+            subqueries = ConcurrentHashMap.newKeySet();
+        }
+        subqueries.add(subquery);
+        return subquery;
     }
 
     @Override
-    public <E> JDOQLTypedSubquery<E> subquery(ListExpression<List<E>, E> candidateList, String candidateAlias)
+    public <E> JDOQLTypedSubquery<E> subquery(ListExpression<List<E>, E> candidateList, Class<E> candidateClass, String candidateAlias)
     {
-        // TODO Implement me
-        throw new JDOException("Method not implemented. Please contribute an implementation via a GitHub pull request");
+        assertIsOpen();
+        discardCompiled();
+        JDOQLTypedSubqueryImpl<E> subquery = new JDOQLTypedSubqueryImpl<E>(pm, this.candidateCls, candidateAlias,
+                (ListExpressionImpl)candidateList, this);
+        if (subqueries == null)
+        {
+            subqueries = ConcurrentHashMap.newKeySet();
+        }
+        subqueries.add(subquery);
+        return subquery;
     }
 
     @Override
-    public <K, V> JDOQLTypedSubquery<Entry<K, V>> subquery(MapExpression<Map<K, V>, K, V> candidateMap, String candidateAlias)
+    public <K, V> JDOQLTypedSubquery<Entry<K, V>> subquery(MapExpression<Map<K, V>, K, V> candidateMap, Class<Entry<K, V>> candidateClass, String candidateAlias)
     {
-        // TODO Implement me
-        throw new JDOException("Method not implemented. Please contribute an implementation via a GitHub pull request");
+        assertIsOpen();
+        discardCompiled();
+        JDOQLTypedSubqueryImpl<Entry<K, V>> subquery = new JDOQLTypedSubqueryImpl<Entry<K, V>>(pm, this.candidateCls,
+                candidateAlias, (MapExpressionImpl)candidateMap, this);
+        if (subqueries == null)
+        {
+            subqueries = ConcurrentHashMap.newKeySet();
+        }
+        subqueries.add(subquery);
+        return subquery;
     }
 
     /* (non-Javadoc)

--- a/src/main/java/org/datanucleus/api/jdo/query/JDOQLTypedSubqueryImpl.java
+++ b/src/main/java/org/datanucleus/api/jdo/query/JDOQLTypedSubqueryImpl.java
@@ -49,6 +49,12 @@ public class JDOQLTypedSubqueryImpl<T> extends AbstractJDOQLTypedQuery<T> implem
         super(pm, candidateClass, candidateAlias, parentQuery);
     }
 
+    public JDOQLTypedSubqueryImpl(PersistenceManager pm, Class<T> candidateClass, String candidateAlias,
+                                  ExpressionImpl<T> candidates, AbstractJDOQLTypedQuery parentQuery)
+    {
+        super(pm, candidateClass, candidates, candidateAlias, parentQuery);
+    }
+
     public String getAlias()
     {
         return "VAR_" + candidateAlias.toUpperCase();


### PR DESCRIPTION
…related subquery

This pull requests provides a (partial) implementation of the JDOQLTypedQuery methods to a create a subquery instance for a correlated subquery, i.e. the subquery FROM clause uses a collection, list or map expression. This pull requests depends on a change in the javax.jdo API classes. I will create a corresponding pull request in the datanucleus javax.jdo repository.