### PR TITLE
JDO-778: fix bug in subquery method, remove two overloaded methods to…

### DIFF
--- a/src/main/java/org/datanucleus/api/jdo/query/JDOQLTypedQueryImpl.java
+++ b/src/main/java/org/datanucleus/api/jdo/query/JDOQLTypedQueryImpl.java
@@ -863,43 +863,16 @@ public class JDOQLTypedQueryImpl<T> extends AbstractJDOQLTypedQuery<T> implement
         return subquery;
     }
 
+    /* (non-Javadoc)
+     * @see javax.jdo.JDOQLTypedQuery#subquery(CollectionExpression, Class, String)
+     */
     @Override
     public <E> JDOQLTypedSubquery<E> subquery(CollectionExpression<Collection<E>, E> candidateCollection, Class<E> candidateClass, String candidateAlias)
     {
         assertIsOpen();
         discardCompiled();
-        JDOQLTypedSubqueryImpl<E> subquery = new JDOQLTypedSubqueryImpl<E>(pm, this.candidateCls, candidateAlias,
+        JDOQLTypedSubqueryImpl<E> subquery = new JDOQLTypedSubqueryImpl<E>(pm, candidateClass, candidateAlias,
                 (CollectionExpressionImpl)candidateCollection, this);
-        if (subqueries == null)
-        {
-            subqueries = ConcurrentHashMap.newKeySet();
-        }
-        subqueries.add(subquery);
-        return subquery;
-    }
-
-    @Override
-    public <E> JDOQLTypedSubquery<E> subquery(ListExpression<List<E>, E> candidateList, Class<E> candidateClass, String candidateAlias)
-    {
-        assertIsOpen();
-        discardCompiled();
-        JDOQLTypedSubqueryImpl<E> subquery = new JDOQLTypedSubqueryImpl<E>(pm, this.candidateCls, candidateAlias,
-                (ListExpressionImpl)candidateList, this);
-        if (subqueries == null)
-        {
-            subqueries = ConcurrentHashMap.newKeySet();
-        }
-        subqueries.add(subquery);
-        return subquery;
-    }
-
-    @Override
-    public <K, V> JDOQLTypedSubquery<Entry<K, V>> subquery(MapExpression<Map<K, V>, K, V> candidateMap, Class<Entry<K, V>> candidateClass, String candidateAlias)
-    {
-        assertIsOpen();
-        discardCompiled();
-        JDOQLTypedSubqueryImpl<Entry<K, V>> subquery = new JDOQLTypedSubqueryImpl<Entry<K, V>>(pm, this.candidateCls,
-                candidateAlias, (MapExpressionImpl)candidateMap, this);
         if (subqueries == null)
         {
             subqueries = ConcurrentHashMap.newKeySet();


### PR DESCRIPTION
… JDOQLTypedQuery to create a correlated subquery

Two changes:
(1) Fixing bug in subquery method taking a CollectionExpression: need to pass the candidateClass provided as parameter (instead of the candidateClass of the outer query) to the JDOQLTypedSubqueryImpl constructor call.

(2) Proposal by JDO conference call Jan 2, 2020: remove the two subquery methods taking a ListExpression and taking a MapExpression as argument. 

Regards Michael